### PR TITLE
Fix binom_test import for SciPy ≥1.10

### DIFF
--- a/src/BorutaShap.py
+++ b/src/BorutaShap.py
@@ -6,7 +6,15 @@ from sklearn.preprocessing import MinMaxScaler
 from sklearn.cluster import KMeans
 from sklearn.inspection import permutation_importance
 from scipy.sparse import issparse
-from scipy.stats import binom_test, ks_2samp
+from scipy.stats import ks_2samp
+# Provide backward compatibility for SciPy >=1.10
+try:
+    from scipy.stats import binom_test  # SciPy < 1.10
+except ImportError:  # SciPy >= 1.10
+    from scipy.stats import binomtest as _binomtest
+
+    def binom_test(x, n=None, p=0.5, alternative="two-sided"):
+        return _binomtest(x, n=n, p=p, alternative=alternative).pvalue
 import matplotlib.pyplot as plt
 from tqdm.auto import tqdm
 import random


### PR DESCRIPTION
## Summary
- update `binom_test` import for newer SciPy
- note backward compatibility in a comment

## Testing
- `PYTHONPATH=src python - <<'PY'
from BorutaShap import BorutaShap
print('instantiating')
bs = BorutaShap()
print('done')
PY`
- `PYTHONPATH=src python - <<'PY'
from BorutaShap import binom_test
print('binom_test result:', binom_test(5, n=10, p=0.5))
PY`


------
https://chatgpt.com/codex/tasks/task_e_686d8cd7cf0c8328b8e13b6fca9ac5db