### PR TITLE
Fix parameter sync, transform(), misc clean-ups

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ def readme():
 
 setup(
     name="BorutaShap",
-    version="1.0.15",
+    version="1.0.16",
     description="A feature selection algorithm.",
     long_description=readme(),
     long_description_content_type="text/markdown",

--- a/src/run_tests.py
+++ b/src/run_tests.py
@@ -15,9 +15,11 @@ def Test_Models(data_type, models):
 
         print('Testing: ' + str(key))
         # no model selected default is Random Forest, if classification is False it is a Regression problem
-        Feature_Selector = BorutaShap(model=value,
-                                        importance_measure='shap',
-                                        classification=True)
+        Feature_Selector = BorutaShap(
+            model=value,
+            importance_measure='shap',
+            classification=(data_type != 'regression')
+        )
 
         Feature_Selector.fit(X=X, y=y, n_trials=5, random_state=0, train_or_test = 'train')
 

--- a/tests/test_critical_paths.py
+++ b/tests/test_critical_paths.py
@@ -51,3 +51,16 @@ def test_tentative_rough_fix_changes_state():
     after = len(fs.accepted) + len(fs.rejected)
     assert after >= before
 
+
+def test_importance_measure_sync():
+    fs = BorutaShap()
+    fs.set_params(importance_measure='gini')
+    assert fs.importance_measure == 'gini'
+
+
+def test_transform_respects_tentative_flag():
+    X, y = load_data('classification')
+    fs = BorutaShap().fit(X, y, n_trials=1, train_or_test='train', verbose=False)
+    assert set(fs.transform(X).columns) == set(fs.accepted)
+    assert set(fs.transform(X, tentative=True).columns) == set(fs.accepted + fs.tentative)
+


### PR DESCRIPTION
## Summary
- normalize importance measure parameter consistently
- make fit return `self`
- update transform to accept data and support tentative features
- improve permutation importance and z-score calculations
- avoid pandas SettingWithCopy warning in plot
- fix backcompat alias
- add missing tests
- ensure run_tests uses correct classification flag
- bump version to 1.0.16

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686da0671dac8328ba0e6cc75c74c1af